### PR TITLE
partial fix for scroll bar offset

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -48,7 +48,7 @@ const StyledHeader = styled.header`
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
+  width: 100vw;
   padding: 0 40px;
   background: var(--bg-color-light);
   backdrop-filter: blur(8px);

--- a/src/components/layout/SideMenu.jsx
+++ b/src/components/layout/SideMenu.jsx
@@ -33,11 +33,11 @@ const StyledNavLinks = styled.ol`
 const StlyedPopupMenu = styled.aside`
   position: fixed;
   top: 0;
-  right: 0;
+  right: calc(0% - (100vw - 100%));
   padding: 40px;
   padding-top: calc(40px + var(--header-height));
   height: 100vh;
-  width: 50%;
+  width: 50vw;
   background: var(--popup-menu-bg, #112240);
   z-index: 2;
 

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -17,12 +17,14 @@ export const GlobalStyles = createGlobalStyle`
 
     body {
         height: 100vh;
+        width: max(100vw, 100%); // exclude scrollbar width
+        overflow-x: hidden; // hide horizontal scrollbar
         margin: 0;
         background: var(--bg-color);
         font-family: "Inter", "Poppins", sans-serif;
         font-size: var(--fs-xl);
 
-        overflow: overlay;
+        overflow-y: overlay;
         overscroll-behavior: none;
 
         line-height: 1.5;


### PR DESCRIPTION
Fix for #1 .

- fix body content from flicking to the right once scrollbar is hidden. Does this by ensuring that the width of the body is `100vw` (includes scrollbar width) rather than just `100%` (does not include the scrollbar width)
- fix menu icon from flicking by doing the same as above but for the header (since its a fixed positioned element)
- fix side menu. By add the scrollbar width offset to the left when scroll bar is not active. This is because  when the opening and closing animation happens, the scrollbar usually hides and pops up respectively. 